### PR TITLE
File fix

### DIFF
--- a/__mocks__/path.js
+++ b/__mocks__/path.js
@@ -11,6 +11,10 @@ const join = (...args) => args.join(sep);
 const extname = srcPath => srcPath.indexOf('.html') >= 0;
 
 const dirname = srcPath => {
+    if(srcPath === 'index.html') {
+        return '.';
+    }
+
     const pathItems = srcPath.split('/');
     pathItems.pop();
     return pathItems.join('/');

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ const copyDirectory = async fileConfig => {
  */
 const copyFile = (fileConfig, file) => {
     const srcFilepath = path.resolve(process.cwd(), file);
-    const filePath = fileConfig.basePath ?
+    const filePath = fileConfig.basePath && fileConfig.basePath !== '.' ?
         file.replace(fileConfig.basePath, '') :
         `${path.sep}${file}`;
     const destFilepath = path.resolve(process.cwd(), fileConfig.dest) + filePath;

--- a/index.test.js
+++ b/index.test.js
@@ -104,7 +104,7 @@ describe('handles troublesome configurations', () => {
         });
     });
 
-    test('errors if src is not a directory', async () => {
+    test('errors if src is a directory that does not exist', async () => {
         const fakeDirectory = 'test/skeletor';
         const config = {
             directories: [
@@ -263,6 +263,22 @@ describe('copies directories', () => {
                 directories: [
                     {
                         src: 'src/skeletor/index.html',
+                        dest: destFilepath1
+                    }
+                ]
+            };
+            const file1 = `${destFilepath1}/index.html`;
+
+            return skeletorStaticFileCopier().run(config, options).then(() => {
+                expect(fseInstance.mockDest).toContain(file1);
+            });
+        });
+
+        test('single file explicit path in same directory', async () => {
+            const config = {
+                directories: [
+                    {
+                        src: 'index.html',
                         dest: destFilepath1
                     }
                 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-copy",
-  "version": "0.2.1",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@deg-skeletor/plugin-copy",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "A Skeletor plugin to copy static assets from one directory to another.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
The plugin was failing to copy a single file properly when the file lived in the current working directory. For example:

```
directories: [{
          src: 'package.json',
          dest: path.resolve(basePath)
}]
```

This was due to the `path.dirname()` method returning `.` for the file. This caused some issues with string replacement in the plugin's `copyFile()` method. 